### PR TITLE
Fix the problem with Redmine comment for a task if use UTF-8 symbol

### DIFF
--- a/share/Git-Redmine-Suite/helpers/perls/bin/redmine-update-task
+++ b/share/Git-Redmine-Suite/helpers/perls/bin/redmine-update-task
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+use utf8::all;
 use GRS 'TaskUpdate';
 
 GRS->run();


### PR DESCRIPTION
```
modified:   share/Git-Redmine-Suite/helpers/perls/bin/redmine-update-task
```
